### PR TITLE
Add RubyRomania to Europe list of meetups

### DIFF
--- a/EUROPE.md
+++ b/EUROPE.md
@@ -260,6 +260,9 @@
 
 #### Romania / România (ro)
 
+- @ Romania
+  - **RubyRomania** (meetup: [ruby-romania](https://rubyromania.ro))
+
 - @ Cluj-Napoca
   - **Cluj.rb** (meetup: [cluj-rb](http://meetup.com/cluj-rb))
 


### PR DESCRIPTION
I added https://rubyromania.ro to the list of meetups and meetup organizers in Romania.

RubyRomania is also organising the https://friendlyrb.com Ruby Conference in Romania and a series of meetups happening in Bucharest and other cities in Romania.